### PR TITLE
Use diederikdehaas' driver for 802.11ac

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 USB Wifiアダプタを２つ挿してアクセスポイントを作ります
 
 Raspbian jessie lite(2015-11-21 kernel 4.1.13)  
-GW-900D (IEEE802.11n 5GHz)  
+GW-900D (IEEE802.11ac 5GHz)  
 GW-USEco300 (IEEE802.11n 2.4GHz)  
 hostapd (アクセスポイントのソフトウェア)  
 

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ rtl8812au チップのドライバーをビルドして使用します
 
 ### Makefile を修正します ##
 
-    diff -u a/Makefile b/Makefile
-    --- a/Makefile
-    +++ b/Makefile
-    @@ -85,8 +85,8 @@
-    ######### Notify SDIO Host Keep Power During Syspend ##########
-    CONFIG_RTW_SDIO_PM_KEEP_POWER = y
-    ###################### Platform Related #######################
-    -CONFIG_PLATFORM_I386_PC = y
-    -CONFIG_PLATFORM_ARM_RPI = n
-    +CONFIG_PLATFORM_I386_PC = n
-    +CONFIG_PLATFORM_ARM_RPI = y
-    CONFIG_PLATFORM_ANDROID_X86 = n
-    CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
-    CONFIG_PLATFORM_JB_X86 = n
+	diff -u a/Makefile b/Makefile
+	--- a/Makefile
+	+++ b/Makefile
+	@@ -85,8 +85,8 @@
+	######### Notify SDIO Host Keep Power During Syspend ##########
+	CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+	###################### Platform Related #######################
+	-CONFIG_PLATFORM_I386_PC = y
+	-CONFIG_PLATFORM_ARM_RPI = n
+	+CONFIG_PLATFORM_I386_PC = n
+	+CONFIG_PLATFORM_ARM_RPI = y
+	CONFIG_PLATFORM_ANDROID_X86 = n
+	CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+	CONFIG_PLATFORM_JB_X86 = n
 
 ### パッチ ##
 
@@ -207,6 +207,7 @@ ssid、wpa_passphrase の箇所は任意に書き換えます
 	wmm_ac_vo_txop_limit=47
 	wmm_ac_vo_acm=0
 	ieee80211n=1
+	ieee80211ac=1
 	eapol_key_index_workaround=0
 	eap_server=0
 	own_ip_addr=127.0.0.1
@@ -215,6 +216,7 @@ ssid、wpa_passphrase の箇所は任意に書き換えます
 	wpa_key_mgmt=WPA-PSK WPA-PSK-SHA256
 	wpa_pairwise=CCMP
 	rsn_pairwise=CCMP
+	
 
 ### /etc/hostapd/hostapd-wlan1.conf ###
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ ssid、wpa_passphrase の箇所は任意に書き換えます
 	ieee80211d=1
 	ieee80211h=1
 	hw_mode=a
-	channel=40
+	channel=153
 	beacon_int=100
 	dtim_period=2
 	max_num_sta=255
@@ -208,6 +208,8 @@ ssid、wpa_passphrase の箇所は任意に書き換えます
 	wmm_ac_vo_acm=0
 	ieee80211n=1
 	ieee80211ac=1
+	vht_oper_chwidth=1
+	vht_oper_centr_freq_seg0_idx=159
 	eapol_key_index_workaround=0
 	eap_server=0
 	own_ip_addr=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ rtl8812au チップのドライバーをビルドして使用します
 
 ### Makefile を修正します ##
 
+    diff -u a/Makefile b/Makefile
     --- a/Makefile
     +++ b/Makefile
     @@ -85,8 +85,8 @@

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 USB Wifiアダプタを２つ挿してアクセスポイントを作ります
 
 Raspbian jessie lite(2015-11-21 kernel 4.1.13)  
-GW-900D (IEEE802.11n 5GHz、※設定がうまくいかず、IEEE802.11acで動作させられませんでした)  
+GW-900D (IEEE802.11n 5GHz)  
 GW-USEco300 (IEEE802.11n 2.4GHz)  
 hostapd (アクセスポイントのソフトウェア)  
 
@@ -50,37 +50,30 @@ hostapd (アクセスポイントのソフトウェア)
 rtl8812au チップのドライバーをビルドして使用します  
 いくつかRaspberry Pi用に設定を変えてビルドします
 
-	git clone --depth 1 https://github.com/abperiasamy/rtl8812AU_8821AU_linux.git
-	cd rtl8812AU_8821AU_linux
+	git clone --depth 1 https://github.com/diederikdehaas/rtl8812AU.git -b driver-4.3.22-beta
+	cd rtl8812AU
 
 ### Makefile を修正します ##
 
-	diff --git Makefile Makefile
-	index 0b4561c..e0e78f0 100644
-	--- Makefile
-	+++ Makefile
-	@@ -49,13 +49,13 @@ CONFIG_EXT_CLK = n
-	 CONFIG_FTP_PROTECT = n
-	 CONFIG_WOWLAN = n
-
-	-CONFIG_PLATFORM_I386_PC = y
-	+CONFIG_PLATFORM_I386_PC = n
-	 CONFIG_PLATFORM_ANDROID_X86 = n
-	 CONFIG_PLATFORM_JB_X86 = n
-	 CONFIG_PLATFORM_ARM_S3C2K4 = n
-	 CONFIG_PLATFORM_ARM_PXA2XX = n
-	 CONFIG_PLATFORM_ARM_S3C6K4 = n
-	-CONFIG_PLATFORM_ARM_RPI = n
-	+CONFIG_PLATFORM_ARM_RPI = y
-	 CONFIG_PLATFORM_MIPS_RMI = n
-	 CONFIG_PLATFORM_RTD2880B = n
-	 CONFIG_PLATFORM_MIPS_AR9132 = n
+    --- a/Makefile
+    +++ b/Makefile
+    @@ -85,8 +85,8 @@
+    ######### Notify SDIO Host Keep Power During Syspend ##########
+    CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+    ###################### Platform Related #######################
+    -CONFIG_PLATFORM_I386_PC = y
+    -CONFIG_PLATFORM_ARM_RPI = n
+    +CONFIG_PLATFORM_I386_PC = n
+    +CONFIG_PLATFORM_ARM_RPI = y
+    CONFIG_PLATFORM_ANDROID_X86 = n
+    CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+    CONFIG_PLATFORM_JB_X86 = n
 
 ### パッチ ##
 
 上記のdiffを保存してパッチ実行する場合 (diff.patch)
 
-	patch -p0 < diff.patch
+	patch -p1 < diff.patch
 
 ### ビルド＆インストール ###
 


### PR DESCRIPTION
The driver-4.3.22-beta branch of diederikdehaas' driver is able to handle 802.11ac. Other branches of his driver do not support 802.11ac. In Japan, the channels may be unavailable because of the regulation and you will need to find other channels.
[vht_oper_centr_freq_seg0_idx is calculated for VHT80 with channel + 6.](https://wireless.wiki.kernel.org/en/users/drivers/ath10k/configuration) In the hostapd.conf, if you set `channel=36`, then set `vht_oper_centr_freq_seg0_idx=42`.